### PR TITLE
Fix handling of addinfo_length - used to crash if addinfo was actually supplied

### DIFF
--- a/lib/knx/src/KnxProtocol.js
+++ b/lib/knx/src/KnxProtocol.js
@@ -479,6 +479,11 @@ KnxProtocol.define('CEMI', {
     })
       .UInt8('msgcode')
       .UInt8('addinfo_length')
+      .tap(function (hdr) {
+        if (hdr.addinfo_length !== 0) {
+          this.raw('addinfo', hdr.addinfo_length);
+        }
+       })
       .raw('ctrl', 2)
       .raw('src_addr', 2)
       .raw('dest_addr', 2)


### PR DESCRIPTION
See https://bitbucket.org/ekarak/knx.js/issues/90/invalid-handling-of-addinfo_length-field for a description